### PR TITLE
fix bug with HAMAP database creation

### DIFF
--- a/bin/prokka-hamap_to_hmm
+++ b/bin/prokka-hamap_to_hmm
@@ -21,7 +21,7 @@ while (<$ali_fh>) {
   my @x = split m/\t/;
   next if $x[5] =~ m/UPF\d+|homolog|[@<\[]/;
   $x[5] =~ s/^probable\s+//gi;
-  $DESC{ $x[1] } = "$sep$x[4]$sep$x[5]";
+  $DESC{ $x[0] } = "$sep$x[4]$sep$x[5]";
 }
 printf STDERR "Accepted descriptions for %d families\n", scalar keys %DESC;
 


### PR DESCRIPTION
I came across an error with a gene name that had been assigned to "QRSL1" when it had matched "MF_00120" which should be "gatA". It turns out that the "alignment_id.dat" file for HAMAP contains some duplicated IDs:
```
MF_00120	MF_00120	17	GATA	gatA	Glutamyl-tRNA(Gln) amidotransferase subunit A
MF_03150	MF_00120	3	GATA	QRSL1	Glutamyl-tRNA(Gln) amidotransferase subunit A, chloroplastic/mitochondrial
```
The first being the bacterial form and the second being the eukaryotic form. Currently prokka uses the second column in this file for the primary identifier, thus the eukaryotic description is being assigned to the bacterial gene. A quick change to the first column would fix this up. One character change pull request enclosed :smile:  