### PR TITLE
Use indexed BLAST DB if already exists

### DIFF
--- a/bin/prokka
+++ b/bin/prokka
@@ -20,6 +20,7 @@
 use strict;
 use warnings;
 use File::Copy;
+use File::Basename;
 use Time::Piece;
 use Time::Seconds;
 use XML::Simple;
@@ -921,12 +922,20 @@ if (-r $proteins) {
   elsif ($format ne 'fasta') {
     err("Option --proteins only supports FASTA, GenBank, and EMBL formats.");
   }
-  runcmd("makeblastdb -dbtype prot -in \Q$faa_file\E -out \Q$outdir/proteins\E -logfile /dev/null");
+  my $blastdb;
+  my ($dbname, $dbpath, $dbsuffix) = fileparse($faa_file, qr/\.[^.]*/);
+  unless  (-f "$dbpath/$dbname.pin" || -f "$dbpath/$dbname.pal") {
+      $blastdb = "$outdir/proteins";
+      runcmd("makeblastdb -dbtype prot -in \Q$faa_file\E -out \Q$blastdb\E -logfile /dev/null");
+  }
+  else {
+      $blastdb = "$dbpath/$dbname";
+  }
   my $src = $proteins;
   $src =~ s{^.*/}{};
   msg("Using /inference source as '$src'");
   unshift @database, {
-    DB  => "$outdir/proteins",
+    DB  => $blastdb,
     SRC => "similar to AA sequence:$src:",
     FMT => 'blast',
     CMD => $BLASTPCMD,


### PR DESCRIPTION
Currently, when given the --proteins argument, prokka will automatically create a BLAST indexed database using the makeblastdb command, regardless of whether or not one already exists. This modification will search the directory of the protein database that is supplied by the user to determine whether an indexed database with the same prefix as the fasta file supplied already exists. If it does, prokka will use that instead of creating a new one.