### PR TITLE
Allowed process substitution as input

### DIFF
--- a/bin/prokka
+++ b/bin/prokka
@@ -398,7 +398,7 @@ msg("Using genetic code table $gcode.");
 # read in sequences; remove small contigs; replace ambig with N
 
 my $in = shift @ARGV or err("Please supply a contig FASTA file on the command line.");
-(-r $in and !-d _ and -s _) or err("'$in' is not a readable non-empty FASTA file");
+(-r $in and !-d _ and (-s _ or -p _)) or err("'$in' is not a readable non-empty FASTA file");
 msg("Loading and checking input file: $in");
 my $fin = Bio::SeqIO->new(-file=>$in, -format=>'fasta');
 my $fout = Bio::SeqIO->new(-file=>">$outdir/$prefix.fna", -format=>'fasta');


### PR DESCRIPTION
When using a process substitution as input, an error is thrown:

    $ prokka <(sed 's/^\(.\+\?\)_length.\+/\1/g' contigs.fasta)
    '/dev/fd/63' is not a readable non-empty FASTA file

Changed input file test so that the input must be readable, not a directory, and either a socket or a pipe.