### PR TITLE
EMBL validator moved (also now versioned)

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,9 +229,9 @@ export PATH=$PATH:$HOME/prokka-1.11/bin
 
 # Download and run the latest EMBL validator prior to submitting the EMBL flat file
 # from http://central.maven.org/maven2/uk/ac/ebi/ena/sequence/embl-api-validator/
-# which at the time of writing is v1.1.1
-% curl -L -O http://central.maven.org/maven2/uk/ac/ebi/ena/sequence/embl-api-validator/1.1.1/embl-api-validator-1.1.1.jar
-% java -jar embl-api-validator-1.1.1.jar -r PRJEB12345/EHEC-Chr1.embl
+# which at the time of writing is v1.1.129
+% curl -L -O http://central.maven.org/maven2/uk/ac/ebi/ena/sequence/embl-api-validator/1.1.129/embl-api-validator-1.1.129.jar
+% java -jar embl-api-validator-1.1.129.jar -r PRJEB12345/EHEC-Chr1.embl
 
 # Compress the file ready to upload to ENA, and calculate MD5 checksum
 % gzip PRJEB12345/EHEC-Chr1.embl

--- a/README.md
+++ b/README.md
@@ -227,9 +227,11 @@ export PATH=$PATH:$HOME/prokka-1.11/bin
     -g linear -c PROK -n 11 -f PRJEB12345/EHEC-Chr1.embl \
     "Escherichia coli" 562 PRJEB12345 "Escherichia coli strain EHEC" PRJEB12345/EHEC-Chr1.gff
 
-# Download and run the EMBL validator prior to submitting the EMBL flat file
-% curl -L -O ftp://ftp.ebi.ac.uk/pub/databases/ena/lib/embl-client.jar
-% java -jar embl-client.jar -r PRJEB12345/EHEC-Chr1.embl
+# Download and run the latest EMBL validator prior to submitting the EMBL flat file
+# from http://central.maven.org/maven2/uk/ac/ebi/ena/sequence/embl-api-validator/
+# which at the time of writing is v1.1.1
+% curl -L -O http://central.maven.org/maven2/uk/ac/ebi/ena/sequence/embl-api-validator/1.1.1/embl-api-validator-1.1.1.jar
+% java -jar embl-api-validator-1.1.1.jar -r PRJEB12345/EHEC-Chr1.embl
 
 # Compress the file ready to upload to ENA, and calculate MD5 checksum
 % gzip PRJEB12345/EHEC-Chr1.embl


### PR DESCRIPTION
The EMBL flat file validator is now on GitHub,
https://github.com/enasequence/sequencetools

The JAR files are released on Maven Central,
https://mvnrepository.com/artifact/uk.ac.ebi.ena.sequence/embl-api-validator

See the recently updated home page,
https://www.ebi.ac.uk/ena/software/flat-file-validator
