### PR TITLE
Fixed barrnap version check when there are locale issues

### DIFF
--- a/bin/prokka
+++ b/bin/prokka
@@ -104,7 +104,7 @@ my %tools = (
     NEEDED  => 0,
   },
   'barrnap' => {
-    GETVER  => "barrnap --version 2>&1",
+    GETVER  => "barrnap --version 2>&1 | grep -i 'barrnap'",
     REGEXP  => qr/($BIDEC)/,  
     MINVER  => "0.4",  
     NEEDED  => 0,


### PR DESCRIPTION
### The problem

When trying to run prokka using barrnap on a linux system that does not have a properly configured locale settings, the barrnap version check fails, even though barrnap is installed. The logging of prokka shows this:

```
  [15:44:14] Looking for 'barrnap' - found /NGStools/miniconda/bin/barrnap
  Use of uninitialized value in concatenation (.) or string at /NGStools/miniconda/bin/prokka line 200.
  [15:44:14] Determined barrnap version is 
  Use of uninitialized value in numeric lt (<) at /NGStools/miniconda/bin/prokka line 201.
  [15:44:14] Prokka needs barrnap 0.4 or higher. Please upgrade and try again.
```

The issue is that when the locale settings are messed up in the system, the output of `barrnap --version` yields:

```
$ barrnap --version
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
        LANGUAGE = "",
        LC_ALL = (unset),
        LC_CTYPE = "en_GB.UTF-8",
        LANG = "en_US.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to a fallback locale ("en_US.UTF-8").
barrnap 0.7
```

This output prevents prokka from getting the proper version of barrnap.

### The solution

In this PR, I simply introduced a `grep` in the version checking of barrnap that fixes this issue, and should be innocuous for the other systems. 