### PR TITLE
Parents written to GFF before children

### DIFF
--- a/bin/prokka
+++ b/bin/prokka
@@ -1225,7 +1225,7 @@ for my $sid (@seq) {
   $fsa_fh->write_seq($ctg);
   $ctg->desc(undef);
   print $tbl_fh ">Feature $sid\n";
-  for my $f ( sort { $a->start <=> $b->start } @{ $seq{$sid}{FEATURE} }) {
+  for my $f ( sort { $a->start <=> $b->start || $b->end <=> $a->end || $a->has_tag('Parent') <=> $b->has_tag('Parent') } @{ $seq{$sid}{FEATURE} }) {
     if ($f->primary_tag eq 'CDS' and not $f->has_tag('product')) {
       $f->add_tag_value('product', $HYPO);
     }


### PR DESCRIPTION
It is commonplace (but neither required, nor specification) for parent features (e.g. `gene`) to precede their child features (e.g. `CDS`) in GFF files.

This branch tweaks the sorting of features before writing to GFF, such that parent features are written before their children. Note that this is only applicable when `--addgenes` or `--addmrna` are invoked, and this change is purely cosmetic.