### PR TITLE
Suppress FASTA in GFF

### DIFF
--- a/bin/prokka
+++ b/bin/prokka
@@ -1225,7 +1225,7 @@ for my $sid (@seq) {
   $fsa_fh->write_seq($ctg);
   $ctg->desc(undef);
   print $tbl_fh ">Feature $sid\n";
-  for my $f ( sort { $a->start <=> $b->start || $b->end <=> $a->end || $a->has_tag('Parent') <=> $b->has_tag('Parent') } @{ $seq{$sid}{FEATURE} }) {
+  for my $f ( sort { $a->start <=> $b->start } @{ $seq{$sid}{FEATURE} }) {
     if ($f->primary_tag eq 'CDS' and not $f->has_tag('product')) {
       $f->add_tag_value('product', $HYPO);
     }

--- a/bin/prokka
+++ b/bin/prokka
@@ -225,7 +225,7 @@ sub check_all_tools {
 # command line options
 
 my(@Options, $quiet, $debug, $kingdom, $fast, $force, $outdir, $prefix, $cpus, 
-             $addgenes, $addmrna, $cds_rna_olap,
+             $addgenes, $addmrna, $cds_rna_olap, $no_fasta_gff,
              $gcode, $gram, $gffver, $locustag, $increment, $mincontiglen, $evalue, $coverage,
              $genus, $species, $strain, $plasmid, 
              $usegenus, $proteins, $hmms, $centre, $scaffolds,
@@ -1275,7 +1275,7 @@ for my $sid (@seq) {
   }
 }
 
-if (@seq) {
+if (@seq and !$no_fasta_gff) {
   print $gff_fh "##FASTA\n";
   my $seqio = Bio::SeqIO->new(-fh=>$gff_fh, -format=>'fasta');
   for my $sid (@seq) {
@@ -1666,6 +1666,7 @@ sub setOptions {
     {OPT=>"compliant!",  VAR=>\$compliant, DEFAULT=>0, DESC=>"Force Genbank/ENA/DDJB compliance: --addgenes --mincontiglen 200 --centre XXX"},
     {OPT=>"centre=s",  VAR=>\$centre, DEFAULT=>'', DESC=>"Sequencing centre ID."},
     {OPT=>"accver=i",  VAR=>\$accver, DEFAULT=>1, DESC=>"Version to put in Genbank file"},
+    {OPT=>"nofastagff!",  VAR=>\$no_fasta_gff, DEFAULT=>0, DESC=>"Do not write FASTA sequence to GFF file."},	     
 #    {OPT=>"scaffolds!",  VAR=>\$scaffolds, DEFAULT=>0, DESC=>"Break scaffoldings into contigs and create .AGP file"},
     'Organism details:',
     {OPT=>"genus=s",  VAR=>\$genus, DEFAULT=>'Genus', DESC=>"Genus name"},


### PR DESCRIPTION
This branch introduces the `--nofastagff` flag, which if added, suppresses the appending of genome FASTA sequences to the end of the GFF file.