### PR TITLE
Remove deprecated ``sudo: false`` from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: perl
 
-sudo: false
-
 perl:
     - "5.26"
     


### PR DESCRIPTION
See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration