### PR TITLE
Updated grep and regexp to fix bug when detecting parallel version

### DIFF
--- a/bin/prokka
+++ b/bin/prokka
@@ -86,8 +86,8 @@ my $BIDEC = '(\d+\.\d+)';  # pattern of NN.NN for versions that can be compared
 
 my %tools = (
   'parallel' => {
-    GETVER  => "parallel --version | grep '^GNU parallel 2'",
-    REGEXP  => qr/GNU parallel (\d+)/,
+    GETVER  => "parallel --version | grep -E 'parallel 2[0-9]{7}\$'",
+    REGEXP  => qr/parallel (\d+)/,
     MINVER  => "20130422",
     NEEDED  => 1,
   },


### PR DESCRIPTION
On some Linux distribution (among which Arch Linux derivatives) the output of `parallel --version` is as follows:

``` bash
$ parallel --version
  parallel 20190322
  Copyright (C) 2007-2019 Ole Tange and Free Software Foundation, Inc.
  License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
  This is free software: you are free to change and redistribute it.
  parallel comes with no warranty.
```
Since Prokka is looking for `GNU parallel yyyymmdd`, it fails to detect parallel's version on the aforementioned distributions.
The changes applied by this pull address this issue.