### PR TITLE
Closing .fsa and .fna files

### DIFF
--- a/bin/prokka
+++ b/bin/prokka
@@ -469,6 +469,7 @@ while (my $seq = $fin->next_seq) {
   push @seq, $id;  # this array it used to preserve original contig order
   $total_bp += $seq->length;
 }
+$fout->close();
 $ncontig > 0 or err("FASTA file '$in' contains no suitable sequence entries");
 msg("Wrote $ncontig contigs totalling $total_bp bp.");
 
@@ -1363,6 +1364,7 @@ for my $sid (@seq) {
     print ${tsv_fh} tsv_line( map { $_ || '' } @values );
   }
 }
+$fsa_fh->close();
 
 if (@seq) {
   print $gff_fh "##FASTA\n";


### PR DESCRIPTION
This problem came about when running prokka in Galaxy on Kubernetes with `outdir` on an NFS volume.
`prokka` would only work the second time it was called, the first time failing with

```
[barrnap] ERROR: bad line in nhmmer output - Fatal exception (source file esl_buffer.c, line 1599):
java.lang.NullPointerException
	at FASTAReader.isFASTA(FASTAReader.java:32)
	at CRISPRFinder.goCRISPRFinder(CRISPRFinder.java:114)
	at minced.main(minced.java:259)
```
I then noticed that deleting `outdir` after the first run made the second run also fail, then noticed that specifically having `outdir/prokka.fsa` and `outdir/prokka.fna` alone was enough to make it pass. I believe this is because on the NFS, the files will not appear when writing without closing, but on a local filesystem it isn't a problem. After adding the following two lines, closing the files, `prokka` passed on the NFS!