### PR TITLE
missing -r operator in checking indexes

### DIFF
--- a/bin/prokka
+++ b/bin/prokka
@@ -323,7 +323,7 @@ msg("Annotating as >>> $kingdom <<<");
 # . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 
 # check if --setupdb has been run
 
-if ( !  -r "$dbdir/kingdom/$kingdom/sprot.pin" or ! "$dbdir/hmm/HAMAP.hmm.h3i") {
+if ( !  -r "$dbdir/kingdom/$kingdom/sprot.pin" or ! -r "$dbdir/hmm/HAMAP.hmm.h3i") {
   err("The sequence databases have not been indexed. Please run 'prokka --setupdb' first.");
 }
 


### PR DESCRIPTION
Lack of `HAMAP.hmm.h3i` not detected unless adding -r