### PR TITLE
Prodigal: don't set metagenome mode if training file given

### DIFF
--- a/bin/prokka
+++ b/bin/prokka
@@ -710,8 +710,12 @@ if ($tools{'minced'}->{HAVE}) {
 # CDS
 
 msg("Predicting coding sequences");
+#check that training file is readable, if given
+if (defined $prodigaltf && ! -r $prodigaltf) {
+    err("Cannot open specified training file for reading: ", $prodigaltf);
+}
 my $totalbp = sum( map { $seq{$_}{DNA}->length } @seq);
-my $prodigal_mode = ($totalbp >= 100000 && !$metagenome) ? 'single' : 'meta';
+my $prodigal_mode = ($totalbp >= 100000 && !$metagenome) || defined $prodigaltf ? 'single' : 'meta';
 msg("Contigs total $totalbp bp, so using $prodigal_mode mode");
 my $num_cds=0;
 my $cmd = "prodigal -i \Q$outdir/$prefix.fna\E -c -m -g $gcode -p $prodigal_mode -f sco -q";


### PR DESCRIPTION
Currently, when running prodigal, prokka automatically sets anonymous (formerly metagenome) mode when the total input sequences are shorter than 100,000 bases. If a training file is specified with the `--prodigaltf` option, it is ignored by prodigal because of this.

The current patch changes the behavior to not set anonymous mode if a training file is specified, regardless of input length. It also adds a check to make sure the prodigal file is readable, and croaks if not (currently this is silently ignored).