### PR TITLE
Link `--proteins` section of manual to `fasta-db-format` section

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ as the first priority, use the `--proteins myfile.gbk`. Please make sure it has 
 recognisable file extension like `.gb` or `.gbk` or auto-detect will fail.   The
 use of Genbank is recommended over FASTA, because it will provide `/gene` 
 and `/EC_number` annotations that a typical `.faa` file will not provide, unless
-you have specially formatted it for Prokka.
+you have [specially formatted it for Prokka](#fasta-database-format).
 
 ### Option: --prodigaltf
 


### PR DESCRIPTION
Hopefully addresses recurring issues that I and others have
encountered (#10, #525) with taking an unnecessarily long time to find
this information. I expected it to be mentioned here, but was confused
not to find it mentioned or linked, so started searching GitHub issues
afterwards.

Thanks for your consideration and for Prokka overall!